### PR TITLE
Fix unescaped UNIT_DELAY defines

### DIFF
--- a/verilog/dv/scan_controller/Makefile
+++ b/verilog/dv/scan_controller/Makefile
@@ -48,7 +48,7 @@ ifeq ($(GATES),yes)
   COMPILE_ARGS    += -DGL_TEST
   COMPILE_ARGS    += -DFUNCTIONAL
   COMPILE_ARGS    += -DSIM
-  COMPILE_ARGS    += -DUNIT_DELAY=#1
+  COMPILE_ARGS    += -DUNIT_DELAY=\#1
   VERILOG_SOURCES += $(PDK_ROOT)/sky130A/libs.ref/sky130_fd_sc_hd/verilog/primitives.v
   VERILOG_SOURCES += $(PDK_ROOT)/sky130A/libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v
   SIM_BUILD       := sim_build_gates

--- a/verilog/dv/scan_controller_ext/Makefile
+++ b/verilog/dv/scan_controller_ext/Makefile
@@ -22,7 +22,7 @@ coco_test: scan_controller.hex
 	mkdir sim_build/
 
     # change project_tb.v to match your testbench name
-	iverilog -Ttyp -DFUNCTIONAL -DSIM -DUSE_POWER_PINS -DUNIT_DELAY=#1 \
+	iverilog -Ttyp -DFUNCTIONAL -DSIM -DUSE_POWER_PINS -DUNIT_DELAY=\#1 \
 	-f$(VERILOG_PATH)/includes/includes.rtl.caravel \
 	-f$(USER_PROJECT_VERILOG)/includes/includes.rtl.$(CONFIG) -o sim_build/sim.vvp scan_controller_tb.v
 

--- a/verilog/dv/scan_controller_int/Makefile
+++ b/verilog/dv/scan_controller_int/Makefile
@@ -22,7 +22,7 @@ coco_test: scan_controller.hex
 	mkdir sim_build/
 
     # change project_tb.v to match your testbench name
-	iverilog -Ttyp -DFUNCTIONAL -DSIM -DUSE_POWER_PINS -DUNIT_DELAY=#1 \
+	iverilog -Ttyp -DFUNCTIONAL -DSIM -DUSE_POWER_PINS -DUNIT_DELAY=\#1 \
 	-f$(VERILOG_PATH)/includes/includes.rtl.caravel \
 	-f$(USER_PROJECT_VERILOG)/includes/includes.rtl.$(CONFIG) -o sim_build/sim.vvp scan_controller_tb.v
 

--- a/verilog/dv/scan_controller_la/Makefile
+++ b/verilog/dv/scan_controller_la/Makefile
@@ -22,7 +22,7 @@ coco_test: scan_controller.hex
 	mkdir sim_build/
 
     # change project_tb.v to match your testbench name
-	iverilog -Ttyp -DFUNCTIONAL -DSIM -DUSE_POWER_PINS -DUNIT_DELAY=#1 \
+	iverilog -Ttyp -DFUNCTIONAL -DSIM -DUSE_POWER_PINS -DUNIT_DELAY=\#1 \
 	-f$(VERILOG_PATH)/includes/includes.rtl.caravel \
 	-f$(USER_PROJECT_VERILOG)/includes/includes.rtl.$(CONFIG) -o sim_build/sim.vvp scan_controller_tb.v
 


### PR DESCRIPTION
Some of these unescaped delays could cause Makefile line continuations from being recognized.